### PR TITLE
Bubble and errorBubble message design changes.

### DIFF
--- a/src/components/messageBox/bubble.tsx
+++ b/src/components/messageBox/bubble.tsx
@@ -23,6 +23,7 @@ export default function Bubble({ role, message, messageType }: IProps) {
                 ? 'bg-[#F5F5F5] text-black'
                 : 'bg-[#141414] text-white'
             } p-3 rounded-2xl`}
+            style={{ whiteSpace: 'pre-line' }}
           >
             <ReactMarkdown children={message} remarkPlugins={[remarkGfm]} />
           </div>

--- a/src/components/messageBox/errorBubble.tsx
+++ b/src/components/messageBox/errorBubble.tsx
@@ -7,8 +7,10 @@ export default function ErrorBubble({ error }: IProps) {
     <div className="flex justify-start">
       <div className="max-w-md mx-2 my-2">
         <div className="flex justify-start">
-          <div className="bg-[#F5F5F5] text-black font-semi-bold p-3 rounded-2xl">
-            <p className="block">Error: {error}</p>
+          <div 
+            className="bg-[#F5F5F5] text-black font-semi-bold p-3 rounded-2xl" 
+            style={{ whiteSpace: 'pre-line' }}>
+              <p className="block">Error: {error}</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
formating the escape chars in the response of the open API's API.  After-> It will now format the escape chars of the message.

`Bubble `and `errorBubble `message design changes.

Before-> it was not formatting the escape chars in the response of the openAPI's API.

After-> It will now format the escape chars of the message.